### PR TITLE
fix mask JSON round-trip, add bayesian engine & VIT viewer

### DIFF
--- a/utils/mask_manager.py
+++ b/utils/mask_manager.py
@@ -85,12 +85,19 @@ class MaskManager:
         JSON [X,Y] = [col, row] in raw detector coordinates.
         Our mask is mask[row, col], so Pixel [X,Y] → mask[Y, X] = True.
         """
-        if detector_shape is None:
-            raise ValueError(
-                "detector_shape=(rows, cols) required for JSON mask loading")
-
         with open(filepath, 'r') as f:
             data = json.load(f)
+
+        # Fall back to "Detector size" embedded in JSON if caller didn't provide shape
+        if detector_shape is None:
+            det_size = data.get('Detector size')
+            if det_size is not None and len(det_size) >= 2:
+                # JSON stores [X, Y] = [cols, rows]; convert to (rows, cols)
+                detector_shape = (int(det_size[1]), int(det_size[0]))
+            else:
+                raise ValueError(
+                    "detector_shape=(rows, cols) required for JSON mask loading "
+                    "and the JSON file does not contain a 'Detector size' key")
 
         bad_pixels = data.get('Bad pixels', [])
         mask = np.zeros(detector_shape, dtype=bool)
@@ -128,7 +135,11 @@ class MaskManager:
         for row, col in zip(rows, cols):
             bad_pixels.append({"Pixel": [int(col), int(row)], "Set": set_value})
 
-        data = {"Bad pixels": bad_pixels}
+        mask_rows, mask_cols = self.mask.shape
+        data = {
+            "Detector size": [int(mask_cols), int(mask_rows)],
+            "Bad pixels": bad_pixels
+        }
         with open(filepath, 'w') as f:
             json.dump(data, f, indent=2)
 

--- a/utils/vit_stitch.py
+++ b/utils/vit_stitch.py
@@ -1,0 +1,766 @@
+"""
+LiveStitch-style patching/stitching for vit:1:input_phase.
+Produces five panels: transmission, diffraction, beam position, NN prediction, NN stitched.
+Used by PVAReader when subscribing to vit:1:input_phase.
+Works with or without PyTorch (numpy fallback when torch unavailable).
+"""
+from math import pi
+import os
+import numpy as np
+
+try:
+    import torch
+    from torch import Tensor
+    _USE_TORCH = True
+except Exception as e:
+    torch = None
+    Tensor = None
+    _USE_TORCH = False
+    print(f"[vit_stitch] PyTorch not available ({e}); using numpy backend. Stitching will still work.")
+
+try:
+    import h5py
+except ImportError:
+    h5py = None
+
+# Stitch pad and stream layout (match LiveStitch4 / LiveStitch6)
+STREAM_SHAPE = (512, 256)
+DIFF_ROWS, PATCH_ROWS = 256, 256
+# Patch crop: 32 -> data[32:-32] (192x192); 66 -> data[66:-66] (124x124) for LiveStitch4
+PAD = 32  # pad argument to place_patches_fourier_shift (crop after shift)
+
+
+# ---------- NumPy backend (used when torch is not available) ----------
+def _batch_put_np(image: np.ndarray, patches: np.ndarray, sy: np.ndarray, sx: np.ndarray, op: str) -> np.ndarray:
+    h, w = image.shape[-2:]
+    ph, pw = patches.shape[-2], patches.shape[-1]
+    n = len(sy)
+    sy = np.asarray(sy, dtype=np.int64)
+    sx = np.asarray(sx, dtype=np.int64)
+    # inds[i, r, c] = (sy[i] + r) * w + (sx[i] + c)
+    rr = np.arange(ph, dtype=np.int64)[:, None, None]  # (ph, 1, 1)
+    cc = np.arange(pw, dtype=np.int64)[None, :, None]  # (1, pw, 1)
+    row = rr + sy[None, None, :]   # (ph, 1, n)
+    col = cc + sx[None, None, :]   # (1, pw, n)
+    inds = (row * w + col).transpose(2, 0, 1).ravel()  # (n, ph, pw) -> ravel
+    vals = patches.ravel()
+    out = image.ravel().copy()
+    # Bounds check: avoid out-of-range indices (can cause black output or crashes)
+    valid = (inds >= 0) & (inds < out.size)
+    if not np.all(valid):
+        inds = inds[valid]
+        vals = vals[valid]
+    if op == "add":
+        np.add.at(out, inds, vals)
+    else:
+        out[inds] = vals
+    return out.reshape(h, w)
+
+
+def _fourier_shift_np(images: np.ndarray, shifts: np.ndarray) -> np.ndarray:
+    ft = np.fft.fft2(images.astype(np.complex128), norm=None)
+    ny, nx = images.shape[-2], images.shape[-1]
+    freq_y = np.fft.fftfreq(ny)
+    freq_x = np.fft.fftfreq(nx)
+    freq_yy, freq_xx = np.meshgrid(freq_y, freq_x, indexing="ij")
+    # shifts (n, 2): [dy, dx]; expand to (n, 1, 1) for broadcast with (1, ny, nx)
+    dy = np.asarray(shifts[:, 0], dtype=np.float64).reshape(-1, 1, 1)
+    dx = np.asarray(shifts[:, 1], dtype=np.float64).reshape(-1, 1, 1)
+    phase = -2j * pi * (freq_xx[None, :, :] * dx + freq_yy[None, :, :] * dy)
+    mult = np.exp(phase)
+    shifted = np.fft.ifft2(ft * mult, norm=None).real
+    return shifted.astype(images.dtype)
+
+
+def _place_patches_fourier_shift_np(
+    image: np.ndarray,
+    positions: np.ndarray,
+    patches: np.ndarray,
+    op: str,
+    adjoint_mode: bool,
+    pad: int,
+) -> np.ndarray:
+    if patches.ndim == 2:
+        patches = np.broadcast_to(patches[None, :, :], (positions.shape[0], patches.shape[0], patches.shape[1])).copy()
+    ph, pw = patches.shape[-2], patches.shape[-1]
+    patch_padding = pad if adjoint_mode else -pad
+    sys_float = positions[:, 0] - (ph - 1.0) / 2.0
+    sxs_float = positions[:, 1] - (pw - 1.0) / 2.0
+    sys = np.floor(sys_float).astype(np.int64) - patch_padding
+    eys = sys + ph + 2 * patch_padding
+    sxs = np.floor(sxs_float).astype(np.int64) - patch_padding
+    exs = sxs + pw + 2 * patch_padding
+    fractional_shifts = np.column_stack([sys_float - sys - patch_padding, sxs_float - sxs - patch_padding])
+    pad_lengths = [
+        max(int(-sxs.min()), 0),
+        max(int(exs.max() - image.shape[1]), 0),
+        max(int(-sys.min()), 0),
+        max(int(eys.max() - image.shape[0]), 0),
+    ]
+    image = np.pad(image, ((pad_lengths[2], pad_lengths[3]), (pad_lengths[0], pad_lengths[1])), mode="constant", constant_values=0)
+    sys = sys + pad_lengths[2]
+    eys = eys + pad_lengths[2]
+    sxs = sxs + pad_lengths[0]
+    exs = exs + pad_lengths[0]
+    if not np.allclose(fractional_shifts, 0, atol=1e-7):
+        patches = _fourier_shift_np(patches, fractional_shifts)
+    if not adjoint_mode:
+        pads = abs(patch_padding)
+        patches = patches[:, pads : patches.shape[1] - pads, pads : patches.shape[2] - pads]
+    image = _batch_put_np(image, patches, sys, sxs, op=op)
+    image = image[
+        pad_lengths[2] : image.shape[0] - pad_lengths[3],
+        pad_lengths[0] : image.shape[1] - pad_lengths[1],
+    ]
+    return image
+
+
+# ---------- PyTorch backend (when available) ----------
+if _USE_TORCH:
+    def _batch_put(
+        image: Tensor,
+        patches: Tensor,
+        sy: Tensor,
+        sx: Tensor,
+        op: str,
+    ) -> Tensor:
+        h, w = image.shape[-2:]
+        patch_size = patches.shape[-2:]
+        x = torch.arange(patch_size[1], device=sx.device)[None, :]
+        y = torch.arange(patch_size[0], device=sy.device)[None, :]
+        x = x.expand(len(sx), x.shape[1])
+        y = y.expand(len(sy), y.shape[1])
+        x = x + sx[:, None]
+        y = y + sy[:, None]
+        inds = (y * w).unsqueeze(-1) + x.unsqueeze(1)
+        image = image.reshape(-1)
+        patches_flattened = patches.reshape(-1)
+        if op == "add":
+            image.scatter_add_(0, inds.view(-1), patches_flattened)
+        else:
+            image.scatter_(0, inds.view(-1), patches_flattened)
+        return image.reshape(h, w)
+
+    def _fourier_shift(images: Tensor, shifts: Tensor) -> Tensor:
+        ft = torch.fft.fft2(images.to(torch.complex128), norm=None)
+        freq_y, freq_x = torch.meshgrid(
+            torch.fft.fftfreq(images.shape[-2], device=images.device),
+            torch.fft.fftfreq(images.shape[-1], device=images.device),
+            indexing="ij",
+        )
+        freq_x = freq_x.to(ft.device).unsqueeze(0).expand(images.shape[0], -1, -1)
+        freq_y = freq_y.to(ft.device).unsqueeze(0).expand(images.shape[0], -1, -1)
+        mult = torch.exp(
+            -2j * pi * (freq_x * shifts[:, 1].view(-1, 1, 1) + freq_y * shifts[:, 0].view(-1, 1, 1))
+        )
+        shifted = torch.fft.ifft2(ft * mult, norm=None).real
+        return shifted.to(images.dtype)
+
+    def _place_patches_fourier_shift(
+        image: Tensor,
+        positions: Tensor,
+        patches: Tensor,
+        op: str,
+        adjoint_mode: bool,
+        pad: int,
+    ) -> Tensor:
+        if patches.dim() == 2:
+            patches = patches.unsqueeze(0).expand(positions.shape[0], -1, -1)
+        ph, pw = patches.shape[-2], patches.shape[-1]
+        patch_padding = pad if adjoint_mode else -pad
+        sys_float = positions[:, 0] - (ph - 1.0) / 2.0
+        sxs_float = positions[:, 1] - (pw - 1.0) / 2.0
+        sys = sys_float.floor().int() - patch_padding
+        eys = sys + ph + 2 * patch_padding
+        sxs = sxs_float.floor().int() - patch_padding
+        exs = sxs + pw + 2 * patch_padding
+        fractional_shifts = torch.stack(
+            [sys_float - sys - patch_padding, sxs_float - sxs - patch_padding], dim=-1
+        )
+        pad_lengths = [
+            max(-sxs.min().item(), 0),
+            max(exs.max().item() - image.shape[1], 0),
+            max(-sys.min().item(), 0),
+            max(eys.max().item() - image.shape[0], 0),
+        ]
+        image = torch.nn.functional.pad(image, pad_lengths)
+        sys = sys + pad_lengths[2]
+        eys = eys + pad_lengths[2]
+        sxs = sxs + pad_lengths[0]
+        exs = exs + pad_lengths[0]
+        if not torch.allclose(fractional_shifts, torch.zeros_like(fractional_shifts), atol=1e-7):
+            patches = _fourier_shift(patches, fractional_shifts)
+        if not adjoint_mode:
+            patches = patches[
+                :,
+                abs(patch_padding) : patches.shape[-2] - abs(patch_padding),
+                abs(patch_padding) : patches.shape[-1] - abs(patch_padding),
+            ]
+        image = _batch_put(image, patches, sys, sxs, op=op)
+        image = image[
+            pad_lengths[2] : image.shape[0] - pad_lengths[3],
+            pad_lengths[0] : image.shape[1] - pad_lengths[1],
+        ]
+        return image
+
+
+def _parse_int_env(name: str, default: int) -> int:
+    v = os.environ.get(name)
+    if v is None:
+        return default
+    try:
+        return int(v)
+    except ValueError:
+        return default
+
+
+# Default CSV path — match LiveStitch7.py reference (no header, col0=y_m, col1=x_m in meters).
+DEFAULT_POSITIONS_CSV = "/home/beams/AILEENLUO/ptycho-vit/workspace/positions_10um.csv"
+
+
+def _find_csv_path(env_path: str = "", explicit_path: str = None) -> str:
+    """Return first existing path: explicit, env, then default CSV path."""
+    if explicit_path and os.path.isfile(explicit_path):
+        return explicit_path
+    if env_path and os.path.isfile(env_path):
+        return env_path
+    if os.path.isfile(DEFAULT_POSITIONS_CSV):
+        return DEFAULT_POSITIONS_CSV
+    return env_path or explicit_path or ""
+
+
+def _find_npz_path(env_path: str = "", explicit_path: str = None) -> str:
+    """Return first existing path: explicit, env, then LiveStitch4-style fallbacks."""
+    if explicit_path and os.path.isfile(explicit_path):
+        return explicit_path
+    if env_path and os.path.isfile(env_path):
+        return env_path
+    _dir = os.path.dirname(os.path.abspath(__file__))
+    cwd = os.getcwd()
+    fallbacks = [
+        os.path.join(cwd, "optimized_route.npz"),
+        os.path.join(_dir, "..", "optimized_route.npz"),
+        os.path.join(_dir, "..", "..", "optimized_route.npz"),
+        "/home/beams/USER26ID/optimized_route.npz",
+        "/home/beams25/USER26ID/optimized_route.npz",
+        os.path.join(os.path.expanduser("~"), "USER26ID", "optimized_route.npz"),
+        os.path.join(os.path.expanduser("~"), "optimized_route.npz"),
+    ]
+    for p in fallbacks:
+        p = os.path.normpath(p)
+        if os.path.isfile(p):
+            return p
+    return env_path or explicit_path or ""
+
+
+class VitStitcher:
+    """
+    Stateful stitcher for vit:1:input_phase stream.
+    Expects stream shape (512, 256): diff = stream[:256,:], data = stream[256:,:].
+    Positions: from CSV (default) if VIT_STITCH_POSITIONS_CSV or default path exists, else npz, else HDF5.
+    Returns five panels: transmission, diffraction, beam_position, nn_prediction, nn_stitched.
+    LiveStitch7: patch_edge_crop=32 (data[32:-32]), id_offset=621356, CSV col0=y_m, col1=x_m.
+    """
+
+    def __init__(
+        self,
+        positions_hdf5_path: str = None,
+        positions_npz_path: str = None,
+        positions_csv_path: str = None,
+        patch_edge_crop: int = None,
+        center_crop_display: int = None,
+    ):
+        self._ready = False
+        self._pos_x_pix = None
+        self._pos_y_pix = None
+        self._object_size = None
+        self._pos_origin_coords = None
+        self._pred_ph = None
+        self._buffer = None
+        self._fly_ny = None
+        self._fly_nx = None
+        self._accu_int = None  # (fly_ny, fly_nx) masked array for transmission panel
+        self._curr_traj = None  # 1D flattened (fly_ny+sq_size)*(fly_nx+sq_size) for beam position
+        self._sq_size = 5
+        self._half_sq_size = 2
+        self._patch_edge_crop = (
+            patch_edge_crop
+            if patch_edge_crop is not None
+            else _parse_int_env("VIT_STITCH_PATCH_EDGE_CROP", 32)
+        )
+        self._center_crop_display = (
+            center_crop_display
+            if center_crop_display is not None
+            else _parse_int_env("VIT_STITCH_CENTER_CROP", 150)
+        )
+        # Load the offset from environment (start-from-correct-place for spiral). Match LiveStitch7 default.
+        self._id_offset = _parse_int_env("VIT_STITCH_ID_OFFSET", 621356)
+        # Reset period set from number of positions when CSV/NPZ load (env override still applies). 0 = disabled.
+        self._reset_period = _parse_int_env("VIT_STITCH_RESET_PERIOD", 0)
+
+        csv_path = _find_csv_path(
+            os.environ.get("VIT_STITCH_POSITIONS_CSV", ""),
+            positions_csv_path,
+        )
+        if csv_path and os.path.isfile(csv_path):
+            self._load_positions_csv(csv_path)
+        else:
+            npz_path = _find_npz_path(
+                os.environ.get("VIT_STITCH_NPZ_PATH", ""),
+                positions_npz_path,
+            )
+            if npz_path and os.path.isfile(npz_path):
+                self._load_positions_npz(npz_path)
+            else:
+                path = positions_hdf5_path or os.environ.get("VIT_STITCH_POSITIONS_HDF5", "")
+                if path and h5py is not None and os.path.isfile(path):
+                    self._load_positions(path)
+                else:
+                    print(
+                        "[VitStitcher] Positions not loaded — prediction and stitching panels will be black. "
+                        "Set VIT_STITCH_POSITIONS_CSV to a CSV path (col0=y_m, col1=x_m in meters) or VIT_STITCH_NPZ_PATH."
+                    )
+
+    def _compute_canvas_size_from_positions(
+        self, pos_x_pix: np.ndarray, pos_y_pix: np.ndarray
+    ) -> tuple:
+        """Compute (obj_h, obj_w) so that all positions fit with patch and margin.
+        Works for both raster (arbitrary min/max) and spiral/circular (centered) scans.
+        Origin remains at canvas center; nothing gets cropped."""
+        patch_side = 256 - 2 * self._patch_edge_crop  # placed patch size
+        margin = int(os.environ.get("VIT_STITCH_OBJECT_MARGIN", "256"))
+        # Require: origin (obj/2) + pos in [patch_side/2, obj - patch_side/2] for both dims
+        half = patch_side / 2.0
+        extent_y = float(np.ceil(2 * max(np.max(pos_y_pix) + half, half - np.min(pos_y_pix))))
+        extent_x = float(np.ceil(2 * max(np.max(pos_x_pix) + half, half - np.min(pos_x_pix))))
+        obj_h = max(int(extent_y) + margin, margin)
+        obj_w = max(int(extent_x) + margin, margin)
+        return (obj_h, obj_w)
+
+    def _load_positions_npz(self, path: str) -> None:
+        """Load positions from npz. Supports:
+        - 'x_pix', 'y_pix': pixel offsets from center (used as-is).
+        - VIT_STITCH_NPZ_PIXEL_OFFSETS=1: treat 'x', 'y' as pixel offsets from center.
+        - Else: 'x', 'y' in route units with step (step_m = spiral_step * -1e-6) and pixel_size → pixels (LiveStitch4.py convention; e.g. LiveStitch4.py 0.05).
+        """
+        try:
+            data = np.load(path)
+            use_pixel_offsets = os.environ.get("VIT_STITCH_NPZ_PIXEL_OFFSETS", "").strip().lower() in ("1", "true", "yes")
+            if "x_pix" in data and "y_pix" in data:
+                pos_x_pix = np.asarray(data["x_pix"], dtype=np.float64)
+                pos_y_pix = np.asarray(data["y_pix"], dtype=np.float64)
+                self._pos_x_pix = pos_x_pix
+                self._pos_y_pix = pos_y_pix
+                mode = "x_pix/y_pix"
+            elif use_pixel_offsets:
+                pos_x_pix = np.asarray(data["x"], dtype=np.float64)
+                pos_y_pix = np.asarray(data["y"], dtype=np.float64)
+                self._pos_x_pix = pos_x_pix
+                self._pos_y_pix = pos_y_pix
+                mode = "pixel offsets (VIT_STITCH_NPZ_PIXEL_OFFSETS=1)"
+            else:
+                step_raw = float(os.environ.get("VIT_STITCH_STEP", "0.05"))
+                # LiveStitch4.py 0.05 → step in meters = 0.05 * -1e-6; accept either spiral_step (0.05) or step_m (-5e-8)
+                step = (step_raw * -1e-6) if (0 < step_raw <= 100) else step_raw
+                pixel_size = float(os.environ.get("VIT_STITCH_PIXEL_SIZE", "6.89e-9"))
+                x_m = np.asarray(data["x"], dtype=np.float64) * step
+                y_m = np.asarray(data["y"], dtype=np.float64) * step
+                pos_x_pix = -x_m / pixel_size
+                pos_y_pix = y_m / pixel_size
+                self._pos_x_pix = np.asarray(pos_x_pix, dtype=np.float64)
+                self._pos_y_pix = np.asarray(pos_y_pix, dtype=np.float64)
+                mode = "meters (step/pixel_size)"
+
+            # Object size: from env if both set, else from position range (raster or spiral; no crop)
+            obj_h_env = os.environ.get("VIT_STITCH_OBJECT_H", "").strip()
+            obj_w_env = os.environ.get("VIT_STITCH_OBJECT_W", "").strip()
+            if obj_h_env.isdigit() and obj_w_env.isdigit():
+                obj_h = int(obj_h_env)
+                obj_w = int(obj_w_env)
+            elif len(self._pos_x_pix) > 0 and len(self._pos_y_pix) > 0:
+                obj_h, obj_w = self._compute_canvas_size_from_positions(
+                    self._pos_x_pix, self._pos_y_pix
+                )
+            else:
+                obj_h = 1161
+                obj_w = 1161
+            self._object_size = (obj_h, obj_w)
+            origin = np.round(np.array(self._object_size, dtype=np.float64) / 2.0) + 0.5
+
+            if _USE_TORCH:
+                self._pos_origin_coords = (torch.tensor(self._object_size, dtype=torch.float32) / 2.0).round() + 0.5
+                self._pred_ph = torch.zeros(self._object_size, dtype=torch.float32)
+                self._buffer = torch.zeros(self._object_size, dtype=torch.float32)
+            else:
+                self._pos_origin_coords = origin.astype(np.float64)
+                self._pred_ph = np.zeros(self._object_size, dtype=np.float32)
+                self._buffer = np.zeros(self._object_size, dtype=np.float32)
+
+            self._ready = True
+            npos = len(self._pos_x_pix)
+            if self._reset_period == 0 and npos > 0:
+                self._reset_period = npos
+            self._init_transmission_beam(npos)
+            backend = "torch" if _USE_TORCH else "numpy"
+            print(f"[VitStitcher] LiveStitch4 positions loaded from {path} — {npos} points, object {self._object_size}, backend={backend}, mode={mode}, reset_period={self._reset_period}")
+
+            # Sanity check: first position after adding origin should be inside image
+            if npos > 0:
+                py0 = self._pos_y_pix[0] + origin[0]
+                px0 = self._pos_x_pix[0] + origin[1]
+                if py0 < -50 or py0 > obj_h + 50 or px0 < -50 or px0 > obj_w + 50:
+                    print(
+                        "[VitStitcher] WARNING: Positions are outside the image (first pos_after_origin=({:.1f},{:.1f}), image {}x{}). "
+                        "Set VIT_STITCH_NPZ_PIXEL_OFFSETS=1 if your NPZ stores pixel offsets from center.".format(
+                            py0, px0, obj_h, obj_w
+                        )
+                    )
+        except Exception as e:
+            print(f"[VitStitcher] Failed to load positions from npz {path}: {e}")
+
+    def _init_transmission_beam(self, npos: int) -> None:
+        """Initialize fly_ny, fly_nx, accu_int, curr_traj for transmission and beam position panels (LiveStitch7 style)."""
+        fly_nx = _parse_int_env("VIT_STITCH_FLY_NX", 100)
+        fly_ny = npos // fly_nx
+        if fly_ny * fly_nx != npos:
+            fly_ny = int(np.sqrt(npos))
+            fly_nx = npos // fly_ny
+            if fly_ny * fly_nx != npos:
+                fly_nx = npos
+                fly_ny = 1
+        fly_ny_env = os.environ.get("VIT_STITCH_FLY_NY", "").strip()
+        if fly_ny_env.isdigit():
+            fly_ny = int(fly_ny_env)
+            fly_nx = npos // fly_ny if fly_ny > 0 else fly_nx
+        self._fly_nx = fly_nx
+        self._fly_ny = fly_ny
+        self._accu_int = np.ma.masked_array(
+            data=np.zeros((fly_ny, fly_nx), dtype=np.float64),
+            mask=np.ones((fly_ny, fly_nx), dtype=bool),
+        )
+        # curr_traj: 1D flattened (fly_ny+sq_size)*(fly_nx+sq_size) with cursor pattern at top-left (LiveStitch7)
+        traj_shape = (self._fly_ny + self._sq_size, self._fly_nx + self._sq_size)
+        self._curr_traj = np.zeros(traj_shape, dtype=np.float64)
+        self._curr_traj[self._half_sq_size, : self._sq_size] = 1
+        self._curr_traj[: self._sq_size, self._half_sq_size] = 1
+        self._curr_traj = self._curr_traj.flatten()
+
+    def _load_positions_csv(self, path: str) -> None:
+        """Load positions from CSV: no header, col0=y_m, col1=x_m (meters). Converts to pixels via VIT_STITCH_PIXEL_SIZE.
+        Object size (prediction/stitch canvas) is computed from position range so all positions fit with patch margin.
+        Matches LiveStitch7 column order and sign convention."""
+        try:
+            data = np.loadtxt(path, delimiter=",", dtype=np.float64)
+            if data.ndim == 1:
+                data = data.reshape(-1, 2)
+            y_m = np.asarray(data[:, 0], dtype=np.float64)
+            x_m = np.asarray(data[:, 1], dtype=np.float64)
+            pixel_size = float(os.environ.get("VIT_STITCH_PIXEL_SIZE", "6.89e-9"))
+            pos_y_pix = y_m / pixel_size
+            pos_x_pix = x_m / pixel_size
+            self._pos_x_pix = pos_x_pix
+            self._pos_y_pix = pos_y_pix
+            # Object size: from env if set, else from position range (raster or spiral; no crop)
+            obj_h_env = os.environ.get("VIT_STITCH_OBJECT_H", "")
+            obj_w_env = os.environ.get("VIT_STITCH_OBJECT_W", "")
+            if obj_h_env.isdigit() and obj_w_env.isdigit():
+                obj_h = int(obj_h_env)
+                obj_w = int(obj_w_env)
+            elif len(pos_x_pix) > 0 and len(pos_y_pix) > 0:
+                obj_h, obj_w = self._compute_canvas_size_from_positions(pos_x_pix, pos_y_pix)
+            else:
+                obj_h = 1161
+                obj_w = 1161
+            self._object_size = (obj_h, obj_w)
+            origin = np.round(np.array(self._object_size, dtype=np.float64) / 2.0) + 0.5
+            if _USE_TORCH:
+                self._pos_origin_coords = (torch.tensor(self._object_size, dtype=torch.float32) / 2.0).round() + 0.5
+                self._pred_ph = torch.zeros(self._object_size, dtype=torch.float32)
+                self._buffer = torch.zeros(self._object_size, dtype=torch.float32)
+            else:
+                self._pos_origin_coords = origin.astype(np.float64)
+                self._pred_ph = np.zeros(self._object_size, dtype=np.float32)
+                self._buffer = np.zeros(self._object_size, dtype=np.float32)
+            self._ready = True
+            npos = len(self._pos_x_pix)
+            if self._reset_period == 0 and npos > 0:
+                self._reset_period = npos
+            self._init_transmission_beam(npos)
+            backend = "torch" if _USE_TORCH else "numpy"
+            print(f"[VitStitcher] Positions loaded from CSV {path} — {npos} points, object {self._object_size}, backend={backend}, reset_period={self._reset_period}, fly_ny={self._fly_ny}, fly_nx={self._fly_nx}")
+            if npos > 0:
+                py0 = self._pos_y_pix[0] + origin[0]
+                px0 = self._pos_x_pix[0] + origin[1]
+                if py0 < -50 or py0 > obj_h + 50 or px0 < -50 or px0 > obj_w + 50:
+                    print(
+                        "[VitStitcher] WARNING: Positions are outside the image (first pos_after_origin=({:.1f},{:.1f}), image {}x{}).".format(
+                            py0, px0, obj_h, obj_w
+                        )
+                    )
+        except Exception as e:
+            print(f"[VitStitcher] Failed to load positions from CSV {path}: {e}")
+
+    def _load_positions(self, path: str) -> None:
+        try:
+            with h5py.File(path, "r") as h5:
+                pos_pix = np.column_stack(
+                    [h5["probe_position_y_m"][...], h5["probe_position_x_m"][...]]
+                )
+                self._pos_x_pix = pos_pix[:, 1]
+                self._pos_y_pix = pos_pix[:, 0]
+                self._object_size = tuple(h5["object"][0].shape)
+            if _USE_TORCH:
+                self._pos_origin_coords = (torch.tensor(self._object_size, dtype=torch.float32) / 2.0).round() + 0.5
+                self._pred_ph = torch.zeros(self._object_size, dtype=torch.float32)
+                self._buffer = torch.zeros(self._object_size, dtype=torch.float32)
+            else:
+                self._pos_origin_coords = (np.array(self._object_size, dtype=np.float64) / 2.0).round() + 0.5
+                self._pred_ph = np.zeros(self._object_size, dtype=np.float32)
+                self._buffer = np.zeros(self._object_size, dtype=np.float32)
+            self._ready = True
+            npos = len(self._pos_x_pix)
+            if npos > 0:
+                self._init_transmission_beam(npos)
+        except Exception as e:
+            print(f"[VitStitcher] Failed to load positions from {path}: {e}")
+
+    def reset_accumulator(self) -> None:
+        """Zero accumulation buffers (e.g. after detecting missed frames). Safe to call anytime."""
+        if not self._ready or self._pred_ph is None or self._buffer is None:
+            return
+        if _USE_TORCH:
+            self._pred_ph.zero_()
+            self._buffer.zero_()
+        else:
+            self._pred_ph.fill(0)
+            self._buffer.fill(0)
+        if self._accu_int is not None:
+            self._accu_int.data[...] = 0
+            self._accu_int.mask[...] = True
+
+    def _beam_panel_for_uid(self, uid: int) -> np.ndarray:
+        """Build (fly_ny, fly_nx) beam position panel for given uid (LiveStitch7 style roll and crop)."""
+        if self._curr_traj is None or self._fly_ny is None or self._fly_nx is None:
+            return np.zeros((2, 2), dtype=np.float32)  # placeholder
+        fly_ny, fly_nx = self._fly_ny, self._fly_nx
+        sq = self._sq_size
+        half = self._half_sq_size
+        offset = int(uid // fly_nx) * (fly_nx + sq) + half + int(uid % fly_nx)
+        rolled = np.roll(self._curr_traj, offset)
+        traj_2d = rolled.reshape(fly_ny + sq, fly_nx + sq)
+        return traj_2d[half : half + fly_ny, half : half + fly_nx].astype(np.float32)
+
+    def process_frames_batch(self, frames: list) -> tuple:
+        """
+        Batch processing: runs reference-accurate accumulation (clamp buffer to 1 before every add)
+        so newest frame has ~50% weight. Processes batch sequentially; each step uses vectorized
+        place_patches for speed. Returns (composite, [transmission, diffraction, beam_position, nn_prediction, nn_stitched]).
+        """
+        if not frames:
+            return None, None
+
+        # 1. Unpack the batch — frames is list of (stream, unique_id)
+        last_stream, last_unique_id = frames[-1]
+
+        # 2. If not ready (no positions), fallback to single frame logic on the last frame
+        if not self._ready:
+            return self.process_frame(last_stream, last_unique_id)
+
+        # 3. Pre-allocate batch arrays
+        ec = self._patch_edge_crop
+        npos = len(self._pos_x_pix)
+
+        streams = [x[0] for x in frames]
+        batch_stream = np.stack(streams, axis=0) if len(streams) > 1 else np.asarray(streams[0])[None, ...]
+        if batch_stream.ndim == 2:
+            batch_stream = batch_stream[None, ...]
+
+        # Patches: data[ec:-ec, ec:-ec] from bottom half
+        data_patches = batch_stream[:, 256 + ec : -ec, ec:-ec]
+
+        unique_ids = np.array([x[1] for x in frames], dtype=np.int64)
+        if self._reset_period > 0 and (unique_ids[0] - self._id_offset) % self._reset_period == 0:
+            self.reset_accumulator()
+        uids = (unique_ids - self._id_offset) % npos if npos else np.zeros_like(unique_ids)
+
+        batch_ys = self._pos_y_pix[uids]
+        batch_xs = self._pos_x_pix[uids]
+
+        # 4. Run stitching and transmission updates in the same loop
+        if _USE_TORCH:
+            patches_t = torch.from_numpy(data_patches.astype(np.float32))
+            pos_y_t = torch.from_numpy(batch_ys.astype(np.float32))
+            pos_x_t = torch.from_numpy(batch_xs.astype(np.float32))
+            pos_tensor = torch.stack([pos_y_t, pos_x_t], dim=1) + self._pos_origin_coords.to(pos_y_t.device)
+            ones_t = torch.ones_like(patches_t[0:1])
+
+            for i in range(len(patches_t)):
+                curr_pos = pos_tensor[i : i + 1]
+                curr_patch = patches_t[i : i + 1]
+                self._pred_ph = _place_patches_fourier_shift(
+                    self._pred_ph, curr_pos, curr_patch, op="add", adjoint_mode=False, pad=PAD
+                )
+                self._buffer = torch.clamp(self._buffer, max=1.0)
+                self._buffer = _place_patches_fourier_shift(
+                    self._buffer, curr_pos, ones_t, op="add", adjoint_mode=False, pad=PAD
+                )
+                self._pred_ph = self._pred_ph / torch.clamp(self._buffer, min=1.0)
+                if self._accu_int is not None:
+                    uid_i = int(uids[i])
+                    diff_i = np.maximum(batch_stream[i, :256, :], 0.0)
+                    row, col = uid_i // self._fly_nx, uid_i % self._fly_nx
+                    if 0 <= row < self._fly_ny and 0 <= col < self._fly_nx:
+                        self._accu_int.data[row, col] = float(np.sum(diff_i))
+                        self._accu_int.mask[row, col] = False
+
+            acc_np = self._pred_ph.cpu().numpy()
+        else:
+            origin = np.asarray(self._pos_origin_coords, dtype=np.float64)
+            positions = (np.column_stack([batch_ys, batch_xs]) + origin).astype(np.float64)
+            ones_batch = np.ones_like(data_patches[0:1])
+
+            for i in range(len(data_patches)):
+                curr_pos = positions[i : i + 1]
+                curr_patch = data_patches[i : i + 1]
+                self._pred_ph = _place_patches_fourier_shift_np(
+                    self._pred_ph, curr_pos, curr_patch, op="add", adjoint_mode=False, pad=PAD
+                )
+                self._buffer = np.clip(self._buffer, None, 1.0)
+                self._buffer = _place_patches_fourier_shift_np(
+                    self._buffer, curr_pos, ones_batch, op="add", adjoint_mode=False, pad=PAD
+                )
+                self._pred_ph = self._pred_ph / np.clip(self._buffer, 1.0, None)
+                if self._accu_int is not None:
+                    uid_i = int(uids[i])
+                    diff_i = np.maximum(batch_stream[i, :256, :], 0.0)
+                    row, col = uid_i // self._fly_nx, uid_i % self._fly_nx
+                    if 0 <= row < self._fly_ny and 0 <= col < self._fly_nx:
+                        self._accu_int.data[row, col] = float(np.sum(diff_i))
+                        self._accu_int.mask[row, col] = False
+
+            acc_np = self._pred_ph.copy()
+
+        # Prediction panel: raw inference patch
+        single_np = data_patches[-1].copy()
+
+        # 5. Display crops and build five panels
+        diff_panel = np.maximum(last_stream[:256, :], 0.0).astype(np.float32)
+        cc = self._center_crop_display
+        acc_panel = acc_np
+        if cc > 0:
+            h, w = acc_np.shape
+            if h > 2 * cc and w > 2 * cc:
+                acc_panel = acc_np[cc:-cc, cc:-cc].copy()
+        single_panel = single_np
+
+        transmission_panel = self._accu_int.data.astype(np.float32).copy() if self._accu_int is not None else np.zeros((self._fly_ny or 2, self._fly_nx or 2), dtype=np.float32)
+        last_uid = int(uids[-1]) if len(uids) else 0
+        beam_panel = self._beam_panel_for_uid(last_uid)
+
+        panels = [transmission_panel, diff_panel, beam_panel, single_panel, acc_panel]
+        composite = transmission_panel  # PVAReader uses vit_panels; composite kept for shape/backward compat
+        return composite, panels
+
+    def process_frame(self, stream_512_256: np.ndarray, unique_id: int) -> np.ndarray:
+        """
+        stream_512_256: (512, 256) float32 from PVA value.
+        unique_id: PVA uniqueId, used to index position.
+        Returns (composite, panels): panels [transmission, diffraction, beam_position, nn_prediction, nn_stitched].
+        If positions not loaded, returns 5 panels with zeros where needed.
+        """
+        stream = np.asarray(stream_512_256, dtype=np.float32)
+        if stream.shape != STREAM_SHAPE:
+            stream = np.broadcast_to(
+                stream.ravel()[: np.prod(STREAM_SHAPE)].reshape(STREAM_SHAPE),
+                STREAM_SHAPE,
+            ).copy()
+        diff = np.maximum(stream[:DIFF_ROWS, :], 0.0).astype(np.float32)
+        data = stream[DIFF_ROWS:, :]
+
+        data_max = float(np.max(data))
+        if data_max == 0 and not getattr(self, "_zero_data_warned", False):
+            self._zero_data_warned = True
+            print("[VitStitcher] WARNING: Input patch data is all zero. Stitching panels will be black (check shutter / vit:1:input_phase).")
+
+        if not self._ready:
+            transmission = np.zeros((2, 2), dtype=np.float32)
+            beam = np.zeros((2, 2), dtype=np.float32)
+            single = np.zeros_like(diff)
+            acc = np.zeros_like(diff)
+            panels = [transmission, diff.copy(), beam, single, acc]
+            return transmission, panels
+
+        npos = len(self._pos_x_pix)
+        uid = int(unique_id - self._id_offset) % npos if npos else 0
+        if self._reset_period > 0 and (unique_id - self._id_offset) % self._reset_period == 0:
+            self.reset_accumulator()
+
+        if self._accu_int is not None:
+            row, col = uid // self._fly_nx, uid % self._fly_nx
+            if 0 <= row < self._fly_ny and 0 <= col < self._fly_nx:
+                self._accu_int.data[row, col] = float(np.sum(diff))
+                self._accu_int.mask[row, col] = False
+
+        pos_y_pix = float(self._pos_y_pix[uid])
+        pos_x_pix = float(self._pos_x_pix[uid])
+        ec = self._patch_edge_crop
+        patch = data[ec:-ec, ec:-ec].astype(np.float32)
+
+        if _USE_TORCH:
+            pos_tensor = torch.tensor([[pos_y_pix, pos_x_pix]], dtype=torch.float32) + self._pos_origin_coords
+            patch_t = torch.from_numpy(patch[np.newaxis, ...].astype(np.float32))
+            ones_t = torch.ones_like(patch_t)
+            self._pred_ph = _place_patches_fourier_shift(self._pred_ph, pos_tensor, patch_t, op="add", adjoint_mode=False, pad=PAD)
+            self._buffer = torch.clamp(self._buffer, max=1.0)
+            self._buffer = _place_patches_fourier_shift(self._buffer, pos_tensor, ones_t, op="add", adjoint_mode=False, pad=PAD)
+            self._pred_ph = self._pred_ph / torch.clamp(self._buffer, min=1.0)
+            acc_np = self._pred_ph.numpy()
+        else:
+            origin = np.asarray(self._pos_origin_coords, dtype=np.float64)
+            positions = (np.array([[pos_y_pix, pos_x_pix]], dtype=np.float64) + origin).astype(np.float64)
+            patch_batch = patch[np.newaxis, :, :]
+            ones_batch = np.ones_like(patch_batch)
+            self._pred_ph = _place_patches_fourier_shift_np(self._pred_ph, positions, patch_batch, op="add", adjoint_mode=False, pad=PAD)
+            self._buffer = np.clip(self._buffer, None, 1.0)
+            self._buffer = _place_patches_fourier_shift_np(self._buffer, positions, ones_batch, op="add", adjoint_mode=False, pad=PAD)
+            self._pred_ph = self._pred_ph / np.clip(self._buffer, 1.0, None)
+            acc_np = self._pred_ph.copy()
+
+        single_np = patch.copy()
+        cc = self._center_crop_display
+        acc_panel = acc_np
+        if cc > 0:
+            h, w = acc_np.shape
+            if h > 2 * cc and w > 2 * cc:
+                acc_panel = acc_np[cc:-cc, cc:-cc].copy()
+        diff_panel = diff.copy()
+        single_panel = single_np
+
+        transmission_panel = self._accu_int.data.astype(np.float32).copy() if self._accu_int is not None else np.zeros((self._fly_ny or 2, self._fly_nx or 2), dtype=np.float32)
+        beam_panel = self._beam_panel_for_uid(uid)
+
+        panels = [transmission_panel, diff_panel, beam_panel, single_panel, acc_panel]
+        return transmission_panel, panels
+
+
+# Module-level singleton for PVAReader (one channel = one stitcher)
+_stitcher = None
+
+
+def get_stitcher(
+    positions_hdf5_path: str = None,
+    positions_npz_path: str = None,
+    positions_csv_path: str = None,
+    patch_edge_crop: int = None,
+    center_crop_display: int = None,
+) -> VitStitcher:
+    global _stitcher
+    if _stitcher is None:
+        _stitcher = VitStitcher(
+            positions_hdf5_path=positions_hdf5_path,
+            positions_npz_path=positions_npz_path,
+            positions_csv_path=positions_csv_path,
+            patch_edge_crop=patch_edge_crop,
+            center_crop_display=center_crop_display,
+        )
+    return _stitcher

--- a/viewer/area_det_viewer.py
+++ b/viewer/area_det_viewer.py
@@ -287,11 +287,8 @@ class DiffractionImageWindow(QMainWindow):
                     det_shape = self.reader.shape[:2]
                 elif self.mask_manager.mask is not None:
                     det_shape = self.mask_manager.mask.shape
-                else:
-                    QMessageBox.warning(self, 'No Image',
-                        'JSON mask requires a detector image to determine dimensions.\n'
-                        'Start streaming first, then load the JSON mask.')
-                    return
+                # If det_shape is still None, _load_json_mask will try
+                # to read "Detector size" from the JSON file itself.
             new_mask = self.mask_manager.load_mask(filepath, detector_shape=det_shape)
         except Exception as e:
             QMessageBox.critical(self, 'Error', f'Failed to load mask:\n{e}')

--- a/viewer/bayesian/bayesian_engine.py
+++ b/viewer/bayesian/bayesian_engine.py
@@ -1,0 +1,552 @@
+"""
+bayesian_engine.py
+==================
+Production Bayesian Optimization Engine for X-ray Beamline 6-ID (APS).
+
+This module provides a self-contained, stateful BayesianOptimizer class that
+wraps GPyTorch's Exact GP framework.  It is designed to operate entirely on
+real experimental data – there is NO simulator or ground-truth logic here.
+
+Mathematical overview
+---------------------
+The GP models a latent function  f: R^2 → R  that maps (x, y) sample
+coordinates to a measured scalar (e.g., an areaDet ROI intensity).
+
+Prior:   f(·) ~ GP(μ(·), k(·,·))
+    μ(·) – constant mean (learned)
+    k(·,·) – ARD Matérn-5/2 kernel (learned length-scales per axis)
+
+Likelihood:  y_i = f(x_i) + ε_i,   ε_i ~ N(0, σ_n²)
+
+Posterior (Exact GP, given training data D = {X, y}):
+    p(f* | X*, D) = N(μ_post(X*), Σ_post(X*, X*))
+
+The kernel hyperparameters (length-scales, output scale, noise) are optimised
+by maximising the exact marginal log-likelihood (MLL) using Adam, run for a
+fixed number of steps after each call to .tell().
+
+Acquisition – Straddle Rule for Level-Set Estimation
+------------------------------------------------------
+We want to map a contour f = threshold (e.g., 0.5 for a binary domain wall).
+The Straddle acquisition function balances:
+    1. Uncertainty reduction  :  large predictive σ*(x)
+    2. Proximity to boundary  :  small |μ*(x) – threshold|
+
+Formally:
+    α(x) = β · σ*(x)  –  |μ*(x) – threshold|
+
+where β controls the exploration–exploitation trade-off (default β = 1.96,
+corresponding to a 95 % credible interval half-width).
+
+Points that are simultaneously uncertain AND close to the estimated level-set
+boundary receive the highest acquisition values and are chosen next.
+
+During an early exploration phase (iteration < explore_until), we drop the
+distance penalty and use α(x) = σ*(x) (pure uncertainty sampling) to avoid
+fixating on a possibly wrong boundary estimate before we have enough data.
+
+Usage (standalone, for testing without Bluesky)
+-----------------------------------------------
+    from bayesian_engine import BayesianOptimizer
+    import numpy as np
+
+    opt = BayesianOptimizer(x_bounds=(0, 100), y_bounds=(0, 100),
+                            grid_nx=64, grid_ny=64)
+
+    # Seed with a few random measurements
+    for _ in range(5):
+        x = np.random.uniform(0, 100)
+        y = np.random.uniform(0, 100)
+        value = my_measurement_function(x, y)   # real or mocked
+        opt.tell(x, y, value)
+
+    # Ask for the next best location
+    next_x, next_y = opt.ask()
+
+    # Fetch grids for plotting
+    mean_grid, std_grid, xi, yi = opt.get_prediction_grid()
+"""
+
+from __future__ import annotations
+
+import logging
+import warnings
+from typing import Optional, Tuple
+
+import numpy as np
+import torch
+import gpytorch
+from torch.optim import Adam
+import linear_operator  # noqa: F401 – used for CG solver settings
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# GP regression model (kernel definition)
+# ---------------------------------------------------------------------------
+
+class _GPRegressionModel(gpytorch.models.ExactGP):
+    """
+    Internal ExactGP model.
+
+    Kernel choice:  ARD Matérn-5/2
+        – 5/2 is twice-differentiable, giving smooth but not hyper-smooth
+          predictions; a good default for physical signals that may have
+          moderate local roughness (domain walls, intensity gradients).
+        – ARD (Automatic Relevance Determination): each input dimension
+          gets its own characteristic length-scale, allowing the GP to
+          discover anisotropy in the (x, y) space automatically.
+
+    The model is deliberately kept kernel-agnostic via the `kernel` parameter
+    so callers can swap it if needed (e.g., RBF for very smooth signals).
+
+    Parameters
+    ----------
+    train_x : torch.Tensor, shape (N, 2)
+        Normalised input coordinates in [0, 1]².
+    train_y : torch.Tensor, shape (N,)
+        Scalar observations.
+    likelihood : gpytorch.likelihoods.GaussianLikelihood
+        Noise model.
+    kernel : str
+        'matern52' (default) or 'rbf'.
+    """
+
+    def __init__(
+        self,
+        train_x: torch.Tensor,
+        train_y: torch.Tensor,
+        likelihood: gpytorch.likelihoods.GaussianLikelihood,
+        kernel: str = "matern52",
+    ) -> None:
+        super().__init__(train_x, train_y, likelihood)
+
+        # Constant mean – a simple but effective prior mean for bounded signals
+        self.mean_module = gpytorch.means.ConstantMean()
+
+        # Kernel selection
+        n_dims = train_x.shape[1]  # should be 2 for (x, y)
+        if kernel == "rbf":
+            base_kernel = gpytorch.kernels.RBFKernel(ard_num_dims=n_dims)
+        else:  # default: matern52
+            base_kernel = gpytorch.kernels.MaternKernel(
+                nu=2.5, ard_num_dims=n_dims
+            )
+
+        # ScaleKernel wraps the base kernel with an output-scale parameter σ_f²,
+        # allowing the amplitude of the GP to be learned from data.
+        self.covar_module = gpytorch.kernels.ScaleKernel(base_kernel)
+
+    def forward(self, x: torch.Tensor) -> gpytorch.distributions.MultivariateNormal:
+        """Compute prior distribution p(f | x) = N(μ(x), k(x, x))."""
+        mean_x = self.mean_module(x)
+        covar_x = self.covar_module(x)
+        return gpytorch.distributions.MultivariateNormal(mean_x, covar_x)
+
+
+# ---------------------------------------------------------------------------
+# Public API: BayesianOptimizer
+# ---------------------------------------------------------------------------
+
+class BayesianOptimizer:
+    """
+    Stateful 2-D Bayesian optimizer backed by a GPyTorch Exact GP.
+
+    All coordinate inputs/outputs use the *physical* coordinate system
+    (i.e., real motor positions in mm or µm as defined by x_bounds /
+    y_bounds).  Internally, coordinates are normalised to [0, 1]² before
+    being passed to the GP, which improves numerical stability of the
+    kernel hyperparameter optimisation.
+
+    Parameters
+    ----------
+    x_bounds : tuple (x_lo, x_hi)
+        Physical range of the X motor.
+    y_bounds : tuple (y_lo, y_hi)
+        Physical range of the Y motor.
+    grid_nx : int
+        Number of grid points along X for the prediction map (default 64).
+    grid_ny : int
+        Number of grid points along Y for the prediction map (default 64).
+    level_set_threshold : float
+        Value at which the level-set boundary is defined (default 0.5).
+        The Straddle acquisition function focuses sampling near this level.
+    beta : float
+        Exploration weight in the Straddle acquisition (default 1.96,
+        corresponding to the 95 % credible interval half-width).
+    explore_until : int
+        Number of data points below which the optimizer uses pure
+        uncertainty sampling instead of the full Straddle rule (default 15).
+    train_iters : int
+        Number of Adam steps used to optimise the MLL after each tell()
+        call (default 50).  Increase for final convergence; decrease for
+        faster per-step latency during a scan.
+    kernel : str
+        Kernel type: 'matern52' (default) or 'rbf'.
+    n_acquisition_candidates : int
+        Size of the random candidate pool evaluated by the acquisition
+        function on each ask() call (default 5000).
+    device : str
+        PyTorch device, e.g., 'cpu' (default) or 'cuda'.
+    """
+
+    def __init__(
+        self,
+        x_bounds: Tuple[float, float] = (0.0, 1.0),
+        y_bounds: Tuple[float, float] = (0.0, 1.0),
+        grid_nx: int = 64,
+        grid_ny: int = 64,
+        level_set_threshold: float = 0.5,
+        beta: float = 1.96,
+        explore_until: int = 15,
+        train_iters: int = 50,
+        kernel: str = "matern52",
+        n_acquisition_candidates: int = 5000,
+        device: str = "cpu",
+    ) -> None:
+        self.x_bounds = x_bounds
+        self.y_bounds = y_bounds
+        self.grid_nx = grid_nx
+        self.grid_ny = grid_ny
+        self.threshold = level_set_threshold
+        self.beta = beta
+        self.explore_until = explore_until
+        self.train_iters = train_iters
+        self.kernel = kernel
+        self.n_candidates = n_acquisition_candidates
+        self.device = torch.device(device)
+
+        # ----------------------------------------------------------------
+        # Training data tensors – grown incrementally by tell()
+        # ----------------------------------------------------------------
+        # train_x_norm: (N, 2) float32 – normalised coords in [0,1]²
+        # train_y:      (N,)   float32 – raw measured scalars
+        self._train_x_norm: Optional[torch.Tensor] = None
+        self._train_y: Optional[torch.Tensor] = None
+
+        # Parallel lists of *physical* coordinates, kept for external use
+        self._x_physical: list[float] = []
+        self._y_physical: list[float] = []
+
+        # GP model and likelihood; created lazily on first tell()
+        self._model: Optional[_GPRegressionModel] = None
+        self._likelihood: Optional[gpytorch.likelihoods.GaussianLikelihood] = None
+
+        # Precompute a fixed evaluation grid (physical coords + normalised)
+        self._build_eval_grid()
+
+        # Tune linear_operator CG solver for larger datasets
+        linear_operator.settings.max_cg_iterations._set_value(2000)
+        linear_operator.settings.cg_tolerance._set_value(0.005)
+
+        logger.info(
+            "BayesianOptimizer initialised: x=[%.3g, %.3g], y=[%.3g, %.3g], "
+            "grid=(%d×%d), kernel=%s",
+            *x_bounds, *y_bounds, grid_nx, grid_ny, kernel,
+        )
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def tell(self, x: float, y: float, value: float) -> None:
+        """
+        Ingest a new experimental measurement and update the GP model.
+
+        Mathematical steps
+        ------------------
+        1. Normalise the physical position (x, y) to the unit square:
+               x_n = (x – x_lo) / (x_hi – x_lo)
+               y_n = (y – y_lo) / (y_hi – y_lo)
+
+        2. Append x_norm = [x_n, y_n] to the training tensor X (N×2)
+           and the scalar `value` to the target tensor y (N,).
+
+        3. If a GP model already exists, update its training data via
+           model.set_train_data() (O(1)) rather than recreating the model
+           from scratch.  The kernel hyperparameters are re-optimised by
+           running `train_iters` steps of Adam on the negative MLL.
+
+        4. The updated model is left in eval mode so get_prediction_grid()
+           and ask() can call it immediately without a mode switch.
+
+        Parameters
+        ----------
+        x : float
+            Physical X coordinate (motor position).
+        y : float
+            Physical Y coordinate (motor position).
+        value : float
+            Measured scalar value (e.g., detector ROI total intensity).
+        """
+        # --- 1. Normalise coordinates to [0, 1]² ---
+        x_n = self._normalise_x(x)
+        y_n = self._normalise_y(y)
+        new_point = torch.tensor([[x_n, y_n]], dtype=torch.float32, device=self.device)
+        new_target = torch.tensor([value], dtype=torch.float32, device=self.device)
+
+        # --- 2. Accumulate training data ---
+        if self._train_x_norm is None:
+            self._train_x_norm = new_point
+            self._train_y = new_target
+        else:
+            self._train_x_norm = torch.cat([self._train_x_norm, new_point], dim=0)
+            self._train_y = torch.cat([self._train_y, new_target], dim=0)
+
+        self._x_physical.append(float(x))
+        self._y_physical.append(float(y))
+
+        n_points = self._train_x_norm.shape[0]
+        logger.debug("tell(): n_data=%d, x=%.4g, y=%.4g, value=%.4g", n_points, x, y, value)
+
+        # --- 3. Build or update GP model ---
+        if self._model is None:
+            # First data point: create the model from scratch
+            self._likelihood = gpytorch.likelihoods.GaussianLikelihood().to(self.device)
+            self._model = _GPRegressionModel(
+                self._train_x_norm,
+                self._train_y,
+                self._likelihood,
+                kernel=self.kernel,
+            ).to(self.device)
+        else:
+            # Subsequent points: inject new data without re-creating the model.
+            # strict=False allows the training inputs to change size.
+            self._model.set_train_data(
+                inputs=self._train_x_norm,
+                targets=self._train_y,
+                strict=False,
+            )
+
+        # --- 4. (Re-)optimise hyperparameters via MLL ---
+        # We need at least 2 data points for MLL to be non-trivial
+        if n_points >= 2:
+            self._train_model()
+
+        # Leave model in eval mode for immediate prediction
+        self._model.eval()
+        self._likelihood.eval()
+
+    def ask(self) -> Tuple[float, float]:
+        """
+        Compute the next recommended measurement location using the
+        Straddle acquisition function.
+
+        Algorithm
+        ---------
+        1. Draw `n_candidates` points uniformly at random in [0, 1]²
+           (the normalised domain).
+
+        2. Compute the GP posterior predictive mean μ* and standard
+           deviation σ* at all candidates via a single batched forward
+           pass (torch.no_grad + fast_pred_var for O(N) cost).
+
+        3. Evaluate the Straddle acquisition:
+               α(x) = β · σ*(x) – |μ*(x) – threshold|
+
+           During early exploration (n_data < explore_until) use:
+               α(x) = σ*(x)    (pure uncertainty sampling)
+
+        4. Return the physical coordinates of the candidate with the
+           highest α value.
+
+        Returns
+        -------
+        x_next : float  –  physical X coordinate
+        y_next : float  –  physical Y coordinate
+
+        Raises
+        ------
+        RuntimeError
+            If called before any data has been provided via tell().
+        """
+        if self._model is None or self._train_x_norm is None:
+            raise RuntimeError(
+                "BayesianOptimizer.ask() called before any data. "
+                "Call tell() with at least one measurement first."
+            )
+
+        n_data = self._train_x_norm.shape[0]
+
+        # --- 1. Random candidate pool in normalised [0,1]² ---
+        candidates = torch.rand(
+            self.n_candidates, 2, dtype=torch.float32, device=self.device
+        )
+
+        # --- 2. Posterior predictions ---
+        self._model.eval()
+        self._likelihood.eval()
+        with torch.no_grad(), gpytorch.settings.fast_pred_var():
+            preds = self._likelihood(self._model(candidates))
+            mu = preds.mean           # shape (n_candidates,)
+            sigma = preds.variance.sqrt()  # shape (n_candidates,)
+
+        # --- 3. Acquisition function ---
+        if n_data < self.explore_until:
+            # Pure exploration: prioritise high-uncertainty regions
+            acquisition = sigma
+            logger.debug(
+                "ask(): exploration phase (n=%d < %d), using pure σ",
+                n_data, self.explore_until,
+            )
+        else:
+            # Straddle rule: balance uncertainty and proximity to level-set
+            distance_from_boundary = torch.abs(mu - self.threshold)
+            acquisition = self.beta * sigma - distance_from_boundary
+            logger.debug(
+                "ask(): straddle phase (n=%d), β=%.2f, threshold=%.2f",
+                n_data, self.beta, self.threshold,
+            )
+
+        # --- 4. Select best candidate and denormalise ---
+        best_idx = torch.argmax(acquisition).item()
+        best_norm = candidates[best_idx]
+
+        x_next = self._denormalise_x(best_norm[0].item())
+        y_next = self._denormalise_y(best_norm[1].item())
+
+        logger.info("ask(): next point → x=%.4g, y=%.4g", x_next, y_next)
+        return x_next, y_next
+
+    def get_prediction_grid(
+        self,
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """
+        Return the GP predictive mean and standard deviation on the
+        pre-built evaluation grid.
+
+        This method is intended to be called by the GUI after each tell()
+        to refresh the 2-D heatmap.
+
+        Returns
+        -------
+        mean_grid : np.ndarray, shape (grid_nx, grid_ny)
+            Predictive mean μ* at each grid point.
+        std_grid  : np.ndarray, shape (grid_nx, grid_ny)
+            Predictive standard deviation σ* at each grid point.
+        xi : np.ndarray, shape (grid_nx,)
+            Physical X coordinates of grid columns.
+        yi : np.ndarray, shape (grid_ny,)
+            Physical Y coordinates of grid rows.
+
+        Raises
+        ------
+        RuntimeError
+            If called before any data has been provided via tell().
+        """
+        if self._model is None:
+            raise RuntimeError(
+                "No GP model available yet. Call tell() with at least one "
+                "measurement before requesting predictions."
+            )
+
+        self._model.eval()
+        self._likelihood.eval()
+
+        with torch.no_grad(), gpytorch.settings.fast_pred_var():
+            # _eval_grid_norm: (grid_nx * grid_ny, 2) tensor
+            preds = self._likelihood(self._model(self._eval_grid_norm))
+            mean_flat = preds.mean.cpu().numpy()
+            std_flat = preds.variance.sqrt().cpu().numpy()
+
+        mean_grid = mean_flat.reshape(self.grid_nx, self.grid_ny)
+        std_grid = std_flat.reshape(self.grid_nx, self.grid_ny)
+
+        return mean_grid, std_grid, self._xi, self._yi
+
+    @property
+    def n_observations(self) -> int:
+        """Number of measurements ingested so far."""
+        if self._train_x_norm is None:
+            return 0
+        return self._train_x_norm.shape[0]
+
+    @property
+    def observed_x(self) -> list[float]:
+        """List of physical X coordinates of all observations (for scatter plot)."""
+        return list(self._x_physical)
+
+    @property
+    def observed_y(self) -> list[float]:
+        """List of physical Y coordinates of all observations (for scatter plot)."""
+        return list(self._y_physical)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _build_eval_grid(self) -> None:
+        """
+        Pre-compute the fixed (grid_nx × grid_ny) evaluation grid used by
+        get_prediction_grid().  This avoids rebuilding tensors on every GUI
+        refresh call.
+        """
+        xi = np.linspace(self.x_bounds[0], self.x_bounds[1], self.grid_nx, dtype=np.float32)
+        yi = np.linspace(self.y_bounds[0], self.y_bounds[1], self.grid_ny, dtype=np.float32)
+        self._xi = xi  # shape (grid_nx,)
+        self._yi = yi  # shape (grid_ny,)
+
+        # Meshgrid → flattened normalised tensor
+        gx, gy = np.meshgrid(xi, yi, indexing="ij")  # (grid_nx, grid_ny) each
+        gx_norm = (gx - self.x_bounds[0]) / max(self.x_bounds[1] - self.x_bounds[0], 1e-9)
+        gy_norm = (gy - self.y_bounds[0]) / max(self.y_bounds[1] - self.y_bounds[0], 1e-9)
+
+        flat_x = gx_norm.ravel().astype(np.float32)
+        flat_y = gy_norm.ravel().astype(np.float32)
+
+        self._eval_grid_norm = torch.from_numpy(
+            np.stack([flat_x, flat_y], axis=-1)
+        ).to(self.device)  # shape (grid_nx * grid_ny, 2)
+
+    def _normalise_x(self, x: float) -> float:
+        lo, hi = self.x_bounds
+        return float((x - lo) / max(hi - lo, 1e-9))
+
+    def _normalise_y(self, y: float) -> float:
+        lo, hi = self.y_bounds
+        return float((y - lo) / max(hi - lo, 1e-9))
+
+    def _denormalise_x(self, x_n: float) -> float:
+        lo, hi = self.x_bounds
+        return float(x_n * (hi - lo) + lo)
+
+    def _denormalise_y(self, y_n: float) -> float:
+        lo, hi = self.y_bounds
+        return float(y_n * (hi - lo) + lo)
+
+    def _train_model(self) -> None:
+        """
+        Optimise GP hyperparameters by maximising the exact marginal
+        log-likelihood (MLL) for `self.train_iters` Adam steps.
+
+        The MLL is:
+            log p(y | X, θ) = –½ yᵀ(K + σ_n²I)⁻¹y  –  ½ log|K + σ_n²I|  –  N/2 log(2π)
+
+        where θ = {length-scales, output-scale, noise variance}.
+
+        Supress GPyTorch's numerical warnings during backprop – these are
+        expected during early optimisation with very few data points and are
+        not indicative of a bug.
+        """
+        assert self._model is not None and self._likelihood is not None
+
+        self._model.train()
+        self._likelihood.train()
+
+        optimizer = Adam(
+            list(self._model.parameters()) + list(self._likelihood.parameters()),
+            lr=0.1,
+        )
+        mll = gpytorch.mlls.ExactMarginalLogLikelihood(self._likelihood, self._model)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            for _ in range(self.train_iters):
+                optimizer.zero_grad()
+                output = self._model(self._train_x_norm)
+                loss = -mll(output, self._train_y)
+                loss.backward()
+                optimizer.step()
+
+        logger.debug("_train_model(): final MLL loss = %.5f", loss.item())

--- a/viewer/bayesian/bayesian_viewer.py
+++ b/viewer/bayesian/bayesian_viewer.py
@@ -168,6 +168,7 @@ class ScanWorker(QThread):
         maxpts: int,
         n_initial: int,
         scalar_key: Optional[str],
+        bluesky_root: Optional[str] = None,
         parent=None,
     ):
         super().__init__(parent)
@@ -183,6 +184,7 @@ class ScanWorker(QThread):
         self.maxpts = maxpts
         self.n_initial = n_initial
         self.scalar_key = scalar_key
+        self.bluesky_root = bluesky_root
         self._abort = False
 
     def request_abort(self) -> None:
@@ -203,12 +205,12 @@ class ScanWorker(QThread):
         # ----------------------------------------------------------------
         try:
             from .bluesky_compat import ensure_bluesky
-            ensure_bluesky()
+            ensure_bluesky(root=self.bluesky_root)
             from bluesky import RunEngine
         except (ImportError, RuntimeError) as exc:
             self.scan_error.emit(
                 f"bluesky import failed: {exc}\n"
-                "Ensure the 6idb-bits conda env is available."
+                "Check the Bluesky Conda Env path in the viewer."
             )
             return
 
@@ -462,6 +464,11 @@ class BayesianViewer(QtWidgets.QMainWindow):
             w.setValue(val)
             return w
 
+        # Bluesky environment
+        from .bluesky_compat import get_bluesky_root
+        self._bluesky_env = _line("path to conda env with bluesky/ophyd")
+        self._bluesky_env.setText(get_bluesky_root())
+
         # PV / device name fields
         self._x_pv = _line("e.g. 6IDA:m1  or  sample_x")
         self._y_pv = _line("e.g. 6IDA:m2  or  sample_y")
@@ -479,6 +486,13 @@ class BayesianViewer(QtWidgets.QMainWindow):
         self._n_init = _spin(1, 1000, 10)
         self._grid_nx = _spin(8, 256, 64)
         self._grid_ny = _spin(8, 256, 64)
+
+        form.addRow("Bluesky Conda Env:", self._bluesky_env)
+
+        sep_env = QtWidgets.QFrame()
+        sep_env.setFrameShape(QtWidgets.QFrame.HLine)
+        sep_env.setStyleSheet("color: #45475a;")
+        form.addRow(sep_env)
 
         form.addRow("X Motor PV / Name:", self._x_pv)
         form.addRow("Y Motor PV / Name:", self._y_pv)
@@ -599,6 +613,7 @@ class BayesianViewer(QtWidgets.QMainWindow):
         self._yi = optimizer._yi
 
         # --- Launch worker ---
+        bluesky_root = self._bluesky_env.text().strip() or None
         self._worker = ScanWorker(
             optimizer=optimizer,
             detector=detector,
@@ -611,6 +626,7 @@ class BayesianViewer(QtWidgets.QMainWindow):
             maxpts=self._maxpts.value(),
             n_initial=self._n_init.value(),
             scalar_key=scalar_key,
+            bluesky_root=bluesky_root,
         )
         self._worker.scan_update.connect(self._on_scan_update)
         self._worker.scan_error.connect(self._on_scan_error)
@@ -718,7 +734,7 @@ class BayesianViewer(QtWidgets.QMainWindow):
         # --- Try direct EPICS construction ---
         try:
             from .bluesky_compat import ensure_bluesky
-            ensure_bluesky()
+            ensure_bluesky(root=self._bluesky_env.text().strip() or None)
             from ophyd import EpicsMotor, Device
 
             x_motor = EpicsMotor(x_name, name="x_motor")
@@ -741,7 +757,7 @@ class BayesianViewer(QtWidgets.QMainWindow):
         # --- Offline / demo mode: ophyd.sim ---
         try:
             from .bluesky_compat import ensure_bluesky
-            ensure_bluesky()
+            ensure_bluesky(root=self._bluesky_env.text().strip() or None)
             from ophyd.sim import SynAxis, SynSignal
 
             x_motor = SynAxis(name=x_name or "sim_x")

--- a/viewer/bayesian/bluesky_compat.py
+++ b/viewer/bayesian/bluesky_compat.py
@@ -1,20 +1,24 @@
 """
 bluesky_compat.py
 =================
-Compatibility layer for importing Bluesky / Ophyd packages from the
-``6idb-bits`` conda environment into the uv-managed DashPVA venv.
+Compatibility layer for importing Bluesky / Ophyd packages from a
+beamline conda environment into the uv-managed DashPVA venv.
 
 DashPVA uses ``uv`` for dependency management, but Bluesky and Ophyd are
-installed in a separate conda environment (``6idb-bits``).  This module
-injects the conda env's ``site-packages`` into ``sys.path`` so that
+installed in the beamline's conda environment.  This module injects the
+conda env's ``site-packages`` into ``sys.path`` so that
 ``import bluesky`` and ``import ophyd`` resolve correctly.
+
+Configuration (pick one, in priority order):
+    1. Pass ``root`` directly to ``ensure_bluesky(root="/path/to/conda/env")``
+    2. Set env var ``DASHPVA_BLUESKY_ROOT=/path/to/conda/env``
+    3. Falls back to the APS 6-IDB default
 
 Usage
 -----
     from viewer.bayesian.bluesky_compat import ensure_bluesky
     ensure_bluesky()          # call once, idempotent
     import bluesky            # now works
-    from bluesky import RunEngine
 """
 
 from __future__ import annotations
@@ -26,68 +30,70 @@ import sys
 
 logger = logging.getLogger(__name__)
 
-# ---------------------------------------------------------------------------
-# Hardcoded paths — edit these if the environment moves
-# ---------------------------------------------------------------------------
-
-#: Root of the conda environment that contains bluesky / ophyd
-CONDA_ENV_ROOT = "/home/beams/USER6IDB/.conda/envs/6idb-bits"
-
-#: Source tree of the 6idb-bits instrument package (for ``id6_b`` devices)
-BITS_SRC_DIR = "/home/beams/USER6IDB/6idb-bits/src"
+_DEFAULT_CONDA_ENV = "/home/beams/USER6IDB/.conda/envs/6idb-bits"
 
 _already_injected = False
+_configured_root: str | None = None
 
 
 def _find_site_packages(env_root: str) -> str | None:
-    """Auto-detect the ``site-packages`` directory inside a conda env.
-
-    Globs ``lib/python*/site-packages`` so the exact Python version
-    (3.11, 3.12, …) does not need to be hardcoded.
-    """
+    """Auto-detect the ``site-packages`` directory inside a conda env."""
     pattern = os.path.join(env_root, "lib", "python*", "site-packages")
     matches = sorted(glob.glob(pattern))
     if matches:
-        return matches[-1]  # pick the highest Python version if multiple
+        return matches[-1]
     return None
 
 
-def ensure_bluesky() -> None:
-    """Inject ``6idb-bits`` conda site-packages into ``sys.path``.
+def get_bluesky_root() -> str:
+    """Return the currently configured conda env root path."""
+    if _configured_root:
+        return _configured_root
+    return os.getenv("DASHPVA_BLUESKY_ROOT", _DEFAULT_CONDA_ENV)
 
-    Safe to call multiple times — subsequent calls are no-ops.
+
+def ensure_bluesky(root: str | None = None) -> None:
+    """Inject beamline conda site-packages into ``sys.path``.
+
+    Parameters
+    ----------
+    root : str, optional
+        Path to the conda environment containing bluesky/ophyd.
+        If provided on the first call, overrides the env var and default.
+        Subsequent calls are no-ops regardless of the ``root`` argument.
 
     Raises
     ------
     RuntimeError
-        If the conda environment or its ``site-packages`` directory cannot
-        be found on disk.
+        If the conda environment or bluesky cannot be found.
     """
-    global _already_injected
+    global _already_injected, _configured_root
     if _already_injected:
         return
 
-    # --- conda env site-packages ---
-    sp = _find_site_packages(CONDA_ENV_ROOT)
+    env_root = root or os.getenv("DASHPVA_BLUESKY_ROOT") or _DEFAULT_CONDA_ENV
+    _configured_root = env_root
+
+    sp = _find_site_packages(env_root)
     if sp is None or not os.path.isdir(sp):
         raise RuntimeError(
-            f"Cannot find site-packages in conda env: {CONDA_ENV_ROOT}\n"
+            f"Cannot find site-packages in conda env: {env_root}\n"
             "Expected a directory matching lib/python*/site-packages.\n"
-            "Please verify that the 6idb-bits conda environment is installed."
+            "Set DASHPVA_BLUESKY_ROOT or pass the path in the viewer GUI."
         )
 
     if sp not in sys.path:
         sys.path.insert(0, sp)
         logger.info("Injected conda site-packages: %s", sp)
 
-    # --- 6idb-bits instrument source (for id6_b devices) ---
-    if os.path.isdir(BITS_SRC_DIR) and BITS_SRC_DIR not in sys.path:
-        sys.path.insert(0, BITS_SRC_DIR)
-        logger.info("Injected 6idb-bits src: %s", BITS_SRC_DIR)
+    # Auto-discover instrument source (e.g. 6idb-bits/src) next to conda env
+    bits_src = os.getenv("DASHPVA_BLUESKY_BITS_SRC", "")
+    if bits_src and os.path.isdir(bits_src) and bits_src not in sys.path:
+        sys.path.insert(0, bits_src)
+        logger.info("Injected instrument src: %s", bits_src)
 
     _already_injected = True
 
-    # Quick smoke test
     try:
         import bluesky  # noqa: F401
         logger.info("bluesky %s imported successfully", bluesky.__version__)

--- a/viewer/mask_viewer.py
+++ b/viewer/mask_viewer.py
@@ -337,8 +337,13 @@ class MaskViewerWindow(QDialog):
             rows, cols = np.where(self.mask)
             for row, col in zip(rows, cols):
                 bad_pixels.append({"Pixel": [int(col), int(row)], "Set": 0})
+            mask_rows, mask_cols = self.mask.shape
+            data = {
+                "Detector size": [int(mask_cols), int(mask_rows)],
+                "Bad pixels": bad_pixels
+            }
             with open(filepath, 'w') as f:
-                json.dump({"Bad pixels": bad_pixels}, f, indent=2)
+                json.dump(data, f, indent=2)
             num = len(bad_pixels)
             self.lbl_info.setText(f"Exported {num} bad pixels to JSON")
         except Exception as e:

--- a/viewer/vit_viewer.py
+++ b/viewer/vit_viewer.py
@@ -1,0 +1,558 @@
+"""
+Standalone VIT (ptychography stitching) viewer.
+
+Displays 5 panels: Transmission, Diffraction, Beam Position, NN Prediction, NN Stitched.
+Uses PVAReader for the PVA connection and VitStitcher for stitching.
+
+Usage:
+    python viewer/vit_viewer.py
+    python viewer/vit_viewer.py --channel vit:1:CSSI
+"""
+import os
+import sys
+import argparse
+
+# --- Stitcher environment (must be set before vit_stitch is imported) ---
+_default_csv = "/home/beams/AILEENLUO/ptycho-vit/workspace/positions_10um.csv"
+if 'VIT_STITCH_POSITIONS_CSV' not in os.environ and os.path.exists(_default_csv):
+    os.environ['VIT_STITCH_POSITIONS_CSV'] = _default_csv
+if 'VIT_STITCH_STEP' not in os.environ:
+    os.environ['VIT_STITCH_STEP'] = "0.05"
+if 'VIT_STITCH_PIXEL_SIZE' not in os.environ:
+    os.environ['VIT_STITCH_PIXEL_SIZE'] = "6.89e-9"
+if 'VIT_STITCH_ID_OFFSET' not in os.environ:
+    os.environ['VIT_STITCH_ID_OFFSET'] = "621356"
+
+print("[VIT Viewer] To change VIT stitch, set before running:")
+print(f"  export VIT_STITCH_POSITIONS_CSV='{os.environ.get('VIT_STITCH_POSITIONS_CSV', '')}'")
+print(f"  export VIT_STITCH_ID_OFFSET='{os.environ.get('VIT_STITCH_ID_OFFSET', '621356')}'")
+print(f"  export VIT_STITCH_STEP='{os.environ.get('VIT_STITCH_STEP', '0.05')}'")
+print(f"  export VIT_STITCH_PIXEL_SIZE='{os.environ.get('VIT_STITCH_PIXEL_SIZE', '6.89e-9')}'")
+
+import numpy as np
+import pyqtgraph as pg
+from PyQt5 import uic
+from PyQt5.QtCore import Qt, QTimer, pyqtSignal
+from PyQt5.QtWidgets import (QApplication, QMainWindow, QCheckBox, QPushButton)
+import pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from utils import rotation_cycle
+from utils import PVAReader
+
+
+rot_gen = rotation_cycle(1, 5)
+
+
+class VitViewerWindow(QMainWindow):
+
+    def __init__(self, input_channel='vit:1:input_phase'):
+        super(VitViewerWindow, self).__init__()
+        uic.loadUi('gui/imageshow.ui', self)
+        self.setWindowTitle('DashPVA — VIT Viewer')
+        self.show()
+        self.reader = None
+        self.image = None
+        self.call_id_plot = 0
+        self.first_plot = True
+        self.image_is_transposed = False
+        self.rot_num = 0
+        self.mouse_x = 0
+        self.mouse_y = 0
+        self._input_channel = input_channel
+        self.pv_prefix.setText(self._input_channel)
+
+        self.timer_labels = QTimer()
+        self.timer_plot = QTimer()
+        self.timer_labels.timeout.connect(self.update_labels)
+        self.timer_plot.timeout.connect(self.update_image)
+
+        # 5-panel layout: Transmission (3x3 left), Diffraction/Beam/Prediction (middle), Stitched (3x3 right)
+        plot = pg.PlotItem()
+        self.image_view = pg.ImageView(view=plot)
+        self.viewer_layout.addWidget(self.image_view, 0, 0, 3, 3)
+
+        plot2 = pg.PlotItem()
+        self.image_view_2 = pg.ImageView(view=plot2)
+        self.image_view_2.view.getAxis('left').setLabel(text='SizeY [pixels]')
+        self.image_view_2.view.getAxis('bottom').setLabel(text='SizeX [pixels]')
+        try:
+            self.image_view_2.getView().getViewBox().invertY(True)
+        except Exception:
+            pass
+        self.viewer_layout.addWidget(self.image_view_2, 0, 3, 1, 1)
+
+        plot3 = pg.PlotItem()
+        self.image_view_3 = pg.ImageView(view=plot3)
+        self.image_view_3.view.getAxis('left').setLabel(text='SizeY [pixels]')
+        self.image_view_3.view.getAxis('bottom').setLabel(text='SizeX [pixels]')
+        try:
+            self.image_view_3.getView().getViewBox().invertY(True)
+        except Exception:
+            pass
+        self.viewer_layout.addWidget(self.image_view_3, 1, 3, 1, 1)
+
+        plot4 = pg.PlotItem()
+        self.image_view_4 = pg.ImageView(view=plot4)
+        self.image_view_4.view.getAxis('left').setLabel(text='SizeY [pixels]')
+        self.image_view_4.view.getAxis('bottom').setLabel(text='SizeX [pixels]')
+        try:
+            self.image_view_4.getView().getViewBox().invertY(True)
+        except Exception:
+            pass
+        self.viewer_layout.addWidget(self.image_view_4, 2, 3, 1, 1)
+
+        plot5 = pg.PlotItem()
+        self.image_view_5 = pg.ImageView(view=plot5)
+        self.image_view_5.view.getAxis('left').setLabel(text='SizeY [pixels]')
+        self.image_view_5.view.getAxis('bottom').setLabel(text='SizeX [pixels]')
+        try:
+            self.image_view_5.getView().getViewBox().invertY(True)
+        except Exception:
+            pass
+        self.viewer_layout.addWidget(self.image_view_5, 0, 4, 3, 3)
+        self.viewer_layout.setRowStretch(0, 1)
+        self.viewer_layout.setRowStretch(1, 1)
+        self.viewer_layout.setRowStretch(2, 1)
+        self.viewer_layout.setColumnStretch(0, 3)
+        self.viewer_layout.setColumnStretch(3, 1)
+        self.viewer_layout.setColumnStretch(4, 3)
+
+        self.image_view.view.getAxis('left').setLabel(text='SizeY [pixels]')
+        self.image_view.view.getAxis('bottom').setLabel(text='SizeX [pixels]')
+
+        # Log checkbox for diffraction panel only
+        self.log_image_1 = QCheckBox('Log (diffraction)')
+        img_layout = getattr(self, 'image_layout', None) or \
+                     (getattr(self, 'formLayoutWidget', None) and self.formLayoutWidget.layout())
+        if img_layout is not None:
+            img_layout.insertRow(5, '', self.log_image_1)
+        self.log_image_1.setChecked(True)
+        self.log_image_1.stateChanged.connect(self.update_image)
+
+        # Magma colormap for all five ImageViews
+        self._vit_colormap = None
+        try:
+            self._vit_colormap = pg.colormap.get('magma')
+        except Exception:
+            try:
+                self._vit_colormap = pg.colormap.get('magma', source='colorcet')
+            except Exception:
+                pass
+
+        _vit_views = (self.image_view, self.image_view_2, self.image_view_3, self.image_view_4, self.image_view_5)
+        if self._vit_colormap is not None:
+            for view in _vit_views:
+                if hasattr(view, 'setColorMap'):
+                    view.setColorMap(self._vit_colormap)
+                elif hasattr(view, 'imageItem'):
+                    lut = self._vit_colormap.getLookupTable(nPts=256)
+                    if lut is not None:
+                        view.imageItem.setLookupTable(lut)
+
+        # Hide non-VIT buttons
+        self.btn_hkl_viewer.setVisible(False)
+        self.btn_save_caches.setVisible(False)
+        self.btn_analysis_window.setVisible(False)
+        self.btn_Stats1.setVisible(False)
+        self.btn_Stats2.setVisible(False)
+        self.btn_Stats3.setVisible(False)
+        self.btn_Stats4.setVisible(False)
+        self.btn_Stats5.setVisible(False)
+        self.display_rois.setVisible(False)
+
+        # Scale bar state
+        self._vit_scale_bar_line = None
+        self._vit_scale_bar_text = None
+        self._vit_scale_bar_added = False
+        self._vit_last_autoscale_log_state = None
+
+        # Signal connections
+        self.pv_prefix.returnPressed.connect(self.start_live_view_clicked)
+        self.pv_prefix.textChanged.connect(self.update_pv_prefix)
+        self.start_live_view.clicked.connect(self.start_live_view_clicked)
+        self.stop_live_view.clicked.connect(self.stop_live_view_clicked)
+        self.rbtn_C.clicked.connect(self.c_ordering_clicked)
+        self.rbtn_F.clicked.connect(self.f_ordering_clicked)
+        self.rotate90degCCW.clicked.connect(self.rotation_count)
+        self.log_image.clicked.connect(self.update_image)
+        self.log_image.clicked.connect(self.reset_first_plot)
+        self.freeze_image.stateChanged.connect(self.freeze_image_checked)
+        self.chk_transpose.stateChanged.connect(self.transpose_image_checked)
+        self.plotting_frequency.valueChanged.connect(self.start_timers)
+        self.max_setting_val.valueChanged.connect(self.update_min_max_setting)
+        self.min_setting_val.valueChanged.connect(self.update_min_max_setting)
+
+        btn_autoscale = getattr(self, "btn_autoscale", None)
+        if btn_autoscale is None:
+            btn_autoscale = QPushButton("Autoscale (5-95%)")
+            btn_autoscale.clicked.connect(self.apply_autoscale)
+            if hasattr(self, "formLayoutWidget_6") and self.formLayoutWidget_6.layout() is not None:
+                self.formLayoutWidget_6.layout().addRow(btn_autoscale)
+            else:
+                parent = self.min_setting_val.parent()
+                if parent is not None and parent.layout() is not None:
+                    parent.layout().addWidget(btn_autoscale)
+        else:
+            btn_autoscale.clicked.connect(self.apply_autoscale)
+
+        self.image_view.getView().scene().sigMouseMoved.connect(self.update_mouse_pos)
+
+    # ---- VIT helpers ----
+
+    def _get_vit_view_levels(self, view) -> tuple:
+        if view is None:
+            return None
+        try:
+            if getattr(view, 'ui', None) is not None and hasattr(view.ui, 'histogram'):
+                return view.ui.histogram.getLevels()
+            if hasattr(view, 'imageItem') and view.imageItem is not None:
+                lev = getattr(view.imageItem, 'levels', None)
+                if lev is not None and len(lev) == 2:
+                    return tuple(lev)
+                if callable(getattr(view.imageItem, 'getLevels', None)):
+                    return view.imageItem.getLevels()
+        except Exception:
+            pass
+        return None
+
+    def _apply_vit_colormap(self) -> None:
+        if not getattr(self, '_vit_colormap', None):
+            return
+        for view in (self.image_view, self.image_view_2, self.image_view_3, self.image_view_4, self.image_view_5):
+            if view is None:
+                continue
+            try:
+                if hasattr(view, 'setColorMap'):
+                    view.setColorMap(self._vit_colormap)
+                elif hasattr(view, 'imageItem'):
+                    lut = self._vit_colormap.getLookupTable(nPts=256)
+                    if lut is not None:
+                        view.imageItem.setLookupTable(lut)
+            except Exception:
+                pass
+
+    def _add_vit_scale_bar(self, height: int, width: int, view=None) -> None:
+        if getattr(self, "_vit_scale_bar_added", False):
+            return
+        target = view if view is not None else self.image_view_5
+        if target is None:
+            return
+        try:
+            pixel_size_m = float(os.environ.get("VIT_STITCH_PIXEL_SIZE", "6.89e-9"))
+            bar_nm = 1000.0  # 1 um
+            bar_px = (bar_nm * 1e-9) / pixel_size_m
+            if bar_px > 0.45 * width:
+                bar_nm = 500.0
+                bar_px = (bar_nm * 1e-9) / pixel_size_m
+            if bar_px < 20:
+                bar_nm = 1000.0
+                bar_px = (bar_nm * 1e-9) / pixel_size_m
+            margin = 20
+            y_bar = height - 1 - margin
+            x0, x1 = margin, margin + int(bar_px)
+            color = "#00ffff"
+            pen = pg.mkPen(color, width=2)
+            self._vit_scale_bar_line = pg.PlotDataItem(x=[x0, x1], y=[y_bar, y_bar], pen=pen)
+            self._vit_scale_bar_line.setZValue(100)
+            target.view.addItem(self._vit_scale_bar_line)
+            bar_label = "1 µm" if bar_nm >= 1000 else f"{bar_nm:.0f} nm"
+            self._vit_scale_bar_text = pg.TextItem(text=bar_label, color=color, anchor=(0, 1))
+            self._vit_scale_bar_text.setZValue(100)
+            self._vit_scale_bar_text.setPos(x0, y_bar - 4)
+            target.view.addItem(self._vit_scale_bar_text)
+            self._vit_scale_bar_added = True
+        except Exception:
+            self._vit_scale_bar_added = True
+
+    # ---- Timers ----
+
+    def start_timers(self) -> None:
+        if self.reader is not None and self.reader.channel.isMonitorActive():
+            self.timer_labels.start(int(1000 / 100))
+            self.timer_plot.start(int(1000 / self.plotting_frequency.value()))
+
+    def stop_timers(self) -> None:
+        self.timer_plot.stop()
+        self.timer_labels.stop()
+
+    # ---- Pixel ordering ----
+
+    def set_pixel_ordering(self) -> None:
+        if self.reader is not None:
+            if self.rbtn_C.isChecked():
+                self.reader.pixel_ordering = 'C'
+                self.reader.image_is_transposed = True
+            elif self.rbtn_F.isChecked():
+                self.reader.pixel_ordering = 'F'
+                self.image_is_transposed = False
+                self.reader.image_is_transposed = False
+
+    def c_ordering_clicked(self) -> None:
+        if self.reader is not None:
+            self.reader.pixel_ordering = 'C'
+            self.reader.image_is_transposed = True
+
+    def f_ordering_clicked(self) -> None:
+        if self.reader is not None:
+            self.reader.pixel_ordering = 'F'
+            self.image_is_transposed = False
+            self.reader.image_is_transposed = False
+
+    # ---- Connection ----
+
+    def start_live_view_clicked(self) -> None:
+        try:
+            self.stop_timers()
+            for view in (self.image_view, self.image_view_2, self.image_view_3, self.image_view_4, self.image_view_5):
+                view.clear()
+            self._vit_last_autoscale_log_state = None
+            self._vit_scale_bar_added = False
+
+            if self.reader is None:
+                self.reader = PVAReader(input_channel=self._input_channel)
+            else:
+                if self.reader.channel.isMonitorActive():
+                    self.reader.stop_channel_monitor()
+                del self.reader
+                self.reader = PVAReader(input_channel=self._input_channel)
+
+            self.set_pixel_ordering()
+            self.transpose_image_checked()
+            self.reader.start_channel_monitor()
+            self.start_timers()
+        except Exception as e:
+            print(f'Failed to Connect to {self._input_channel}: {e}')
+            for view in (self.image_view, self.image_view_2, self.image_view_3, self.image_view_4, self.image_view_5):
+                view.clear()
+            if getattr(self, 'reader', None) is not None:
+                del self.reader
+            self.reader = None
+            self.provider_name.setText('N/A')
+            self.is_connected.setText('Disconnected')
+
+    def stop_live_view_clicked(self) -> None:
+        if self.reader is not None:
+            if self.reader.channel.isMonitorActive():
+                self.reader.stop_channel_monitor()
+            self.stop_timers()
+            self.provider_name.setText('N/A')
+            self.is_connected.setText('Disconnected')
+
+    # ---- UI state ----
+
+    def freeze_image_checked(self) -> None:
+        if self.reader is not None:
+            if self.freeze_image.isChecked():
+                self.stop_timers()
+            else:
+                self.start_timers()
+
+    def transpose_image_checked(self) -> None:
+        if self.chk_transpose.isChecked():
+            self.image_is_transposed = True
+        else:
+            self.image_is_transposed = False
+
+    def reset_first_plot(self) -> None:
+        self.first_plot = True
+
+    def rotation_count(self) -> None:
+        self.rot_num = next(rot_gen)
+
+    def update_pv_prefix(self) -> None:
+        self._input_channel = self.pv_prefix.text()
+
+    # ---- Mouse tracking ----
+
+    def update_mouse_pos(self, pos) -> None:
+        mouse_point = self.image_view.getView().mapSceneToView(pos)
+        self.mouse_x = int(mouse_point.x())
+        self.mouse_y = int(mouse_point.y())
+        self.update_mouse_labels()
+
+    def update_mouse_labels(self) -> None:
+        self.mouse_pos_x.setText(str(self.mouse_x))
+        self.mouse_pos_y.setText(str(self.mouse_y))
+        if self.image is not None:
+            if 0 <= self.mouse_x < self.image.shape[1] and 0 <= self.mouse_y < self.image.shape[0]:
+                self.mouse_pos_val.setText(f"{self.image[self.mouse_y, self.mouse_x]:.4f}")
+
+    # ---- Labels ----
+
+    def update_labels(self) -> None:
+        if self.reader is not None:
+            self.provider_name.setText(self.reader.pva_prefix)
+            self.is_connected.setText('Connected')
+            self.pv_col.setText(str(self.reader.shape[1]) if len(self.reader.shape) >= 2 else 'N/A')
+            self.pv_row.setText(str(self.reader.shape[0]) if len(self.reader.shape) >= 2 else 'N/A')
+            self.pv_data_type.setText(str(self.reader.data_type) if self.reader.data_type else 'N/A')
+            self.pv_timestamp.setText(str(self.reader.timestamp) if self.reader.timestamp else 'N/A')
+            self.pv_frame_recv.setText(str(self.reader.frames_received))
+            self.pv_frame_miss.setText(str(self.reader.frames_missed))
+
+    # ---- Image update (5-panel VIT) ----
+
+    def update_image(self) -> None:
+        if self.reader is None:
+            return
+        self.call_id_plot += 1
+        vit_panels = getattr(self.reader, 'vit_panels', None)
+
+        if vit_panels is not None and len(vit_panels) == 5:
+            panels = [np.asarray(p, dtype=np.float32).copy() for p in vit_panels]
+            panels[1] = np.maximum(panels[1], 0.0)
+            log_diffraction = self.log_image_1.isChecked() if self.log_image_1 else True
+            views = [self.image_view, self.image_view_2, self.image_view_3, self.image_view_4, self.image_view_5]
+
+            for i, p in enumerate(panels):
+                if i == 1:
+                    p = np.transpose(p)
+                if i in (0, 2, 4):
+                    p = np.transpose(p)
+                p = np.transpose(p) if self.image_is_transposed else p
+                p = np.rot90(p, k=self.rot_num)
+                if i == 4:
+                    p = p[:, ::-1].copy()
+                if i == 1 and log_diffraction:
+                    p = np.maximum(p, 0)
+                    p = np.log10(p + 1e-10)
+                    p = np.maximum(p, 0.0)
+                panels[i] = p
+
+            self._add_vit_scale_bar(panels[4].shape[0], panels[4].shape[1], view=self.image_view_5)
+
+            last = getattr(self, "_vit_last_autoscale_log_state", None)
+            run_for_panel = [True] * 5
+            if last is not None and last != log_diffraction:
+                run_for_panel[1] = True
+            if last is None or last != log_diffraction:
+                self._apply_autoscale_vit(panels, views, run_for_panel=run_for_panel)
+                self._vit_last_autoscale_log_state = log_diffraction
+
+            for i, p in enumerate(panels):
+                view = views[i]
+                pmin, pmax = float(np.min(p)), float(np.max(p))
+                levels = self._get_vit_view_levels(view)
+                if levels is not None and len(levels) == 2 and levels[1] > levels[0]:
+                    view.setImage(p, autoRange=False, autoLevels=False, levels=levels, autoHistogramRange=False)
+                elif pmin == pmax:
+                    levels = (pmin, pmin + 1.0) if np.isfinite(pmin) else (0.0, 1.0)
+                    view.setImage(p, autoRange=False, autoLevels=False, levels=levels, autoHistogramRange=False)
+                else:
+                    view.setImage(p, autoRange=False, autoLevels=False, levels=(pmin, pmax), autoHistogramRange=False)
+                view.setVisible(True)
+
+            for i, v in enumerate(views):
+                try:
+                    ar = panels[i].shape[1] / float(max(panels[i].shape[0], 1))
+                    v.view.setAspectLocked(lock=True, ratio=ar)
+                except Exception:
+                    pass
+
+            self.image = panels[1]
+            mn, mx = np.min(panels[1]), np.max(panels[1])
+            self.min_px_val.setText(f"{mn:.2f}")
+            self.max_px_val.setText(f"{mx:.2f}")
+
+    # ---- Autoscale ----
+
+    def _percentile_levels(self, intensities: np.ndarray, p_lo: float = 5.0, p_hi: float = 95.0) -> tuple:
+        intensities = np.asarray(intensities).flatten()
+        intensities = intensities[np.isfinite(intensities)]
+        if len(intensities) == 0:
+            return (0.0, 1.0)
+        data_min = float(np.min(intensities))
+        data_max = float(np.max(intensities))
+        if data_min < -9.0:
+            population = intensities[intensities > -9.0]
+            if len(population) >= 100:
+                intensities = population
+        lo = float(np.percentile(intensities, p_lo))
+        hi = float(np.percentile(intensities, p_hi))
+        if data_min < lo:
+            lo = data_min
+        if hi < data_max:
+            hi = data_max
+        if lo >= hi:
+            hi = lo + 1.0
+        return (lo, hi)
+
+    def _apply_autoscale_vit(self, panels: list, views: list, run_for_panel: list = None) -> None:
+        if run_for_panel is None:
+            run_for_panel = [True] * len(panels)
+        for i, p in enumerate(panels):
+            if i >= len(run_for_panel) or i >= len(views) or not run_for_panel[i]:
+                continue
+            intensities = p.flatten()
+            intensities = intensities[np.isfinite(intensities)]
+            if len(intensities) == 0:
+                continue
+            lo, hi = self._percentile_levels(intensities)
+            views[i].setLevels(lo, hi)
+        if len(panels) > 1 and len(run_for_panel) > 1 and run_for_panel[1]:
+            intensities = panels[1].flatten()
+            intensities = intensities[np.isfinite(intensities)]
+            if len(intensities) > 0:
+                lo, hi = self._percentile_levels(intensities)
+                self.min_setting_val.blockSignals(True)
+                self.max_setting_val.blockSignals(True)
+                self.min_setting_val.setValue(lo)
+                self.max_setting_val.setValue(hi)
+                self.min_setting_val.blockSignals(False)
+                self.max_setting_val.blockSignals(False)
+
+    def apply_autoscale(self) -> None:
+        vit_panels = getattr(self.reader, "vit_panels", None) if self.reader else None
+        if vit_panels is not None and len(vit_panels) == 5:
+            panels = [np.asarray(p, dtype=np.float32).copy() for p in vit_panels]
+            panels[1] = np.maximum(panels[1], 0.0)
+            log_diffraction = self.log_image_1.isChecked() if self.log_image_1 else True
+            views = [self.image_view, self.image_view_2, self.image_view_3, self.image_view_4, self.image_view_5]
+            for i, p in enumerate(panels):
+                if i == 1:
+                    p = np.transpose(p)
+                if i in (0, 2, 4):
+                    p = np.transpose(p)
+                p = np.transpose(p) if self.image_is_transposed else p
+                p = np.rot90(p, k=self.rot_num)
+                if i == 4:
+                    p = p[:, ::-1].copy()
+                if i == 1 and log_diffraction:
+                    p = np.maximum(p, 0)
+                    p = np.log10(p + 1e-10)
+                    p = np.maximum(p, 0.0)
+                panels[i] = p
+            self._apply_autoscale_vit(panels, views)
+            self._vit_last_autoscale_log_state = log_diffraction
+
+    def update_min_max_setting(self) -> None:
+        min_ = self.min_setting_val.value()
+        max_ = self.max_setting_val.value()
+        self.image_view_2.setLevels(min_, max_)
+
+    # ---- Cleanup ----
+
+    def closeEvent(self, event):
+        self.stop_timers()
+        if self.reader is not None:
+            try:
+                if self.reader.channel.isMonitorActive():
+                    self.reader.stop_channel_monitor()
+            except Exception:
+                pass
+        super(VitViewerWindow, self).closeEvent(event)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='DashPVA VIT Viewer — Ptychography Stitching')
+    parser.add_argument('--channel', default='vit:1:input_phase',
+                        help='PVA channel name (default: vit:1:input_phase, 9ID uses vit:1:CSSI)')
+    args = parser.parse_args()
+
+    app = QApplication(sys.argv)
+    window = VitViewerWindow(input_channel=args.channel)
+    sys.exit(app.exec_())
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- **Fix mask JSON round-trip bug**: Export now embeds "Detector size" in JSON so masks can be re-imported without a live stream. Fully compatible with NDPluginBadPixel (extra key is ignored by the IOC).                                           
  - **Add bayesian_engine.py**: Portable Bluesky environment config for Bayesian optimization.                                                                                                                                                         
  - **Add standalone VIT viewer**: For ptychography stitching.